### PR TITLE
Add get variant method to UUID object and specs

### DIFF
--- a/src/main/scala/memeid.scala
+++ b/src/main/scala/memeid.scala
@@ -5,9 +5,10 @@ import cats.kernel._
 import java.lang.Long
 import java.util.{UUID => JUUID}
 
-case class UUID(msb: Long, lsb: Long) 
+case class UUID(msb: Long, lsb: Long)
 
 object UUID {
+  val variantPos = 62
   val empty: UUID = UUID(0, 0)
 
   def toJavaUUID(u: UUID): JUUID =
@@ -16,7 +17,9 @@ object UUID {
   def fromJavaUUID(u: JUUID): UUID =
     UUID(u.getMostSignificantBits, u.getLeastSignificantBits)
 
-  implicit val orderForUUID: Order[UUID] = new Order[UUID]{
+  def getVariant(u: UUID): Int = (u.lsb >>> variantPos).toInt
+
+  implicit val orderForUUID: Order[UUID] = new Order[UUID] {
     def compare(x: UUID, y: UUID): Int = {
       val mc = Long.compareUnsigned(x.msb, y.msb)
       if (mc != 0) {
@@ -27,5 +30,3 @@ object UUID {
     }
   }
 }
-
-

--- a/src/test/scala/UUIDSpec.scala
+++ b/src/test/scala/UUIDSpec.scala
@@ -7,28 +7,38 @@ import org.scalacheck._
 import org.scalacheck.Prop.forAll
 
 object UUIDSpec extends Properties("UUID") {
-  property("round-trips as java.util.UUID") = forAll { (msb: Long, lsb: Long) => 
+  property("round-trips as java.util.UUID") = forAll { (msb: Long, lsb: Long) =>
     val uuid = UUID(msb, lsb)
     val asJava = UUID.toJavaUUID(uuid)
     val asUuid = UUID.fromJavaUUID(asJava)
     uuid === asUuid
   }
 
-  property("compares properly using unsigned comparison") = forAll { (lsb: Long) =>
-    // specifically chosen since they will not compare correctly unless using unsigned comparison
-    val msb = 0x20000000
-    val lmsb = 0xE0000000
-    val aUuid = UUID(msb, lsb)
-    val anotherUuid = UUID(lmsb, lsb)
+  property("compares properly using unsigned comparison") = forAll {
+    (lsb: Long) =>
+      // specifically chosen since they will not compare correctly unless using unsigned comparison
+      val msb = 0x20000000
+      val lmsb = 0xE0000000
+      val aUuid = UUID(msb, lsb)
+      val anotherUuid = UUID(lmsb, lsb)
 
-    Order[UUID].compare(
-      aUuid,
-      anotherUuid
-    ) === -1 &&
-    Order[java.util.UUID].compare(
-      UUID.toJavaUUID(aUuid),
-      UUID.toJavaUUID(anotherUuid)
-    ) === 1
-  }  
+      Order[UUID].compare(aUuid, anotherUuid) === -1 &&
+      Order[java.util.UUID]
+        .compare(UUID.toJavaUUID(aUuid), UUID.toJavaUUID(anotherUuid)) === 1
+  }
+
+  property("detect a valid UUID variant") = forAll { (msb: Long) =>
+    val lsb: Long = 0x9000000000000000L
+    val uuid = UUID(msb, lsb)
+    val variant = UUID.getVariant(uuid)
+    variant === 2
+  }
+
+  property("detect an invalid UUID variant") = forAll { (msb: Long) =>
+    val lsb: Long = 0xC000000000000000L
+    val uuid = UUID(msb, lsb)
+    val variant = UUID.getVariant(uuid)
+    !(variant === 2)
+  }
 
 }


### PR DESCRIPTION
This PR adds a method to get the variant of an UUID and the test cases for determining a valid and an invalid one.