### PR TITLE
Extract object members, add bounds and laws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,3 +4,5 @@ ThisBuild / scalaVersion := "2.12.10"
 
 libraryDependencies += "org.typelevel" %% "cats-effect"       % "2.0.0"
 libraryDependencies += "org.specs2"    %% "specs2-scalacheck" % "4.8.1" % Test
+libraryDependencies += "org.typelevel" %% "cats-laws"         % "2.0.0" % Test
+libraryDependencies += "org.typelevel" %% "discipline-specs2" % "1.0.0" % Test

--- a/src/main/scala/memeid/CatsInstances.scala
+++ b/src/main/scala/memeid/CatsInstances.scala
@@ -1,19 +1,19 @@
 package memeid
 
 import java.lang.Long.compareUnsigned
-import java.util.{UUID => JUUID}
 
 import cats.Show
-import cats.instances.uuid._
+import cats.instances.uuid.catsStdShowForUUID
 import cats.kernel.{Hash, Order}
+import cats.syntax.contravariant._
 
 @SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract"))
 trait CatsInstances {
 
-  implicit val UUIDHashOrderShowInstances: Order[UUID] with Hash[UUID] with Show[UUID] =
-    new Order[UUID] with Hash[UUID] with Show[UUID] {
+  implicit val UUIDHashOrderInstances: Order[UUID] with Hash[UUID] =
+    new Order[UUID] with Hash[UUID] {
 
-      override def hash(x: UUID): Int = Hash[JUUID].hash(x.juuid)
+      override def hash(x: UUID): Int = x.juuid.hashCode /* scalafix:ok */ ()
 
       override def compare(x: UUID, y: UUID): Int =
         compareUnsigned(x.msb, y.msb) match {
@@ -21,7 +21,8 @@ trait CatsInstances {
           case x => x
         }
 
-      override def show(t: UUID): String = Show[JUUID].show(t.juuid)
     }
+
+  implicit val UUIDShowInstance: Show[UUID] = catsStdShowForUUID.contramap(_.juuid)
 
 }

--- a/src/main/scala/memeid/CatsInstances.scala
+++ b/src/main/scala/memeid/CatsInstances.scala
@@ -4,7 +4,7 @@ import java.lang.Long.compareUnsigned
 
 import cats.Show
 import cats.instances.uuid.catsStdShowForUUID
-import cats.kernel.{Hash, Order}
+import cats.kernel.{Hash, LowerBounded, Order, PartialOrder, UpperBounded}
 import cats.syntax.contravariant._
 
 @SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract"))
@@ -24,5 +24,15 @@ trait CatsInstances {
     }
 
   implicit val UUIDShowInstance: Show[UUID] = catsStdShowForUUID.contramap(_.juuid)
+
+  implicit val UUIDBoundsInstances: LowerBounded[UUID] with UpperBounded[UUID] =
+    new LowerBounded[UUID] with UpperBounded[UUID] {
+
+      override def minBound: UUID = UUID.Nil
+
+      override def maxBound: UUID = UUID.from(-1L, -1L)
+
+      override def partialOrder: PartialOrder[UUID] = UUIDHashOrderInstances
+    }
 
 }

--- a/src/main/scala/memeid/CatsInstances.scala
+++ b/src/main/scala/memeid/CatsInstances.scala
@@ -1,0 +1,27 @@
+package memeid
+
+import java.lang.Long.compareUnsigned
+import java.util.{UUID => JUUID}
+
+import cats.Show
+import cats.instances.uuid._
+import cats.kernel.{Hash, Order}
+
+@SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract"))
+trait CatsInstances {
+
+  implicit val UUIDHashOrderShowInstances: Order[UUID] with Hash[UUID] with Show[UUID] =
+    new Order[UUID] with Hash[UUID] with Show[UUID] {
+
+      override def hash(x: UUID): Int = Hash[JUUID].hash(x.juuid)
+
+      override def compare(x: UUID, y: UUID): Int =
+        compareUnsigned(x.msb, y.msb) match {
+          case 0 => compareUnsigned(x.lsb, y.lsb)
+          case x => x
+        }
+
+      override def show(t: UUID): String = Show[JUUID].show(t.juuid)
+    }
+
+}

--- a/src/main/scala/memeid/Constructors.scala
+++ b/src/main/scala/memeid/Constructors.scala
@@ -1,0 +1,15 @@
+package memeid
+
+import java.util.{UUID => JUUID}
+
+import memeid.JavaConverters._
+
+trait Constructors {
+
+  /**
+   * Creates a valid [[UUID]] from two [[Long]] values representing
+   * the most/least significant bits.
+   */
+  def from(msb: Long, lsb: Long): UUID = new JUUID(msb, lsb).asScala
+
+}

--- a/src/main/scala/memeid/UUID.scala
+++ b/src/main/scala/memeid/UUID.scala
@@ -1,12 +1,10 @@
 package memeid
 
-import java.lang.Long.compareUnsigned
 import java.util.{UUID => JUUID}
 
 import scala.reflect.ClassTag
 
 import cats.Show
-import cats.instances.uuid._
 import cats.kernel._
 
 /**
@@ -78,7 +76,7 @@ sealed trait UUID {
 
 }
 
-object UUID extends Constructors {
+object UUID extends Constructors with CatsInstances {
 
   /**
    * The nil UUID is special form of UUID that is specified to have all 128 bits set to zero.
@@ -134,19 +132,5 @@ object UUID extends Constructors {
       val version: Int,
       override private[memeid] val juuid: JUUID
   ) extends UUID
-
-  implicit val UUIDHashOrderShowInstance: Order[UUID] with Hash[UUID] with Show[UUID] =
-    new Order[UUID] with Hash[UUID] with Show[UUID] {
-
-      override def hash(x: UUID): Int = Hash[JUUID].hash(x.juuid)
-
-      override def compare(x: UUID, y: UUID): Int =
-        compareUnsigned(x.msb, y.msb) match {
-          case 0 => compareUnsigned(x.lsb, y.lsb)
-          case x => x
-        }
-
-      override def show(t: UUID): String = Show[JUUID].show(t.juuid)
-    }
 
 }

--- a/src/main/scala/memeid/UUID.scala
+++ b/src/main/scala/memeid/UUID.scala
@@ -9,8 +9,6 @@ import cats.Show
 import cats.instances.uuid._
 import cats.kernel._
 
-import memeid.JavaConverters._
-
 /**
  * A class that represents an immutable universally unique identifier (UUID).
  * A UUID represents a 128-bit value.
@@ -80,7 +78,7 @@ sealed trait UUID {
 
 }
 
-object UUID {
+object UUID extends Constructors {
 
   /**
    * The nil UUID is special form of UUID that is specified to have all 128 bits set to zero.
@@ -136,12 +134,6 @@ object UUID {
       val version: Int,
       override private[memeid] val juuid: JUUID
   ) extends UUID
-
-  /**
-   * Creates a valid [[UUID]] from two [[Long]] values representing
-   * the most/least significant bits.
-   */
-  def from(msb: Long, lsb: Long): UUID = new JUUID(msb, lsb).asScala
 
   implicit val UUIDHashOrderShowInstance: Order[UUID] with Hash[UUID] with Show[UUID] =
     new Order[UUID] with Hash[UUID] with Show[UUID] {

--- a/src/test/scala/memeid/UUIDLaws.scala
+++ b/src/test/scala/memeid/UUIDLaws.scala
@@ -1,0 +1,16 @@
+package memeid
+
+import cats.instances.option._
+import cats.kernel.laws.discipline.{HashTests, LowerBoundedTests, OrderTests, UpperBoundedTests}
+
+import org.specs2.mutable.Specification
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class UUIDLaws extends Specification with Discipline {
+
+  checkAll("UUID", HashTests[UUID].hash)
+  checkAll("UUID", OrderTests[UUID].order)
+  checkAll("UUID", LowerBoundedTests[UUID].lowerBounded)
+  checkAll("UUID", UpperBoundedTests[UUID].upperBounded)
+
+}

--- a/src/test/scala/memeid/package.scala
+++ b/src/test/scala/memeid/package.scala
@@ -3,7 +3,11 @@ import org.scalacheck.Arbitrary.arbitrary
 
 package object memeid {
 
-  implicit val UUIDGenInstance: Arbitrary[UUID] = Arbitrary {
+  implicit val UUID2UUIDArbitraryInstance: Arbitrary[UUID => UUID] = Arbitrary(
+    arbitrary[UUID].map(uuid => { _: UUID => uuid })
+  )
+
+  implicit val UUIDArbitraryInstance: Arbitrary[UUID] = Arbitrary {
     for {
       msb <- arbitrary[Long]
       lsb <- arbitrary[Long]
@@ -11,27 +15,27 @@ package object memeid {
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
-  implicit val UUIDV1GenInstance: Arbitrary[UUID.V1] = Arbitrary {
+  implicit val UUIDV1ArbitraryInstance: Arbitrary[UUID.V1] = Arbitrary {
     arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V1]).map(uuid => new UUID.V1(uuid.juuid))
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
-  implicit val UUIDV2GenInstance: Arbitrary[UUID.V2] = Arbitrary {
+  implicit val UUIDV2ArbitraryInstance: Arbitrary[UUID.V2] = Arbitrary {
     arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V2]).map(uuid => new UUID.V2(uuid.juuid))
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
-  implicit val UUIDV3GenInstance: Arbitrary[UUID.V3] = Arbitrary {
+  implicit val UUIDV3ArbitraryInstance: Arbitrary[UUID.V3] = Arbitrary {
     arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V3]).map(uuid => new UUID.V3(uuid.juuid))
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
-  implicit val UUIDV4GenInstance: Arbitrary[UUID.V4] = Arbitrary {
+  implicit val UUIDV4ArbitraryInstance: Arbitrary[UUID.V4] = Arbitrary {
     arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V4]).map(uuid => new UUID.V4(uuid.juuid))
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
-  implicit val UUIDV5GenInstance: Arbitrary[UUID.V5] = Arbitrary {
+  implicit val UUIDV5ArbitraryInstance: Arbitrary[UUID.V5] = Arbitrary {
     arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V5]).map(uuid => new UUID.V5(uuid.juuid))
   }
 


### PR DESCRIPTION
# What has been done in this PR?

- Extract constructors and cats instances to their own traits so `UUID` class is more simple
- Add law tests for the several cats instances we have
- Add lower/upper bounds for `UUID`

## Why using `UUID(0, 0)`/`UUID(-1, -1)` as lower/upper bounds instead of the ones provided by Cats?

Cats [lower/upper instances for `java.util.UUID`](https://github.com/typelevel/cats/blob/master/kernel/src/main/scala/cats/kernel/instances/UUIDInstances.scala#L16-L17) rely on comparing using `java.util.UUID#compare` which we know [is broken](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=7025832).

Real lower/upper values should be:

- **Lower:** `00000000-0000-0000-0000-000000000000`
- **Upper:** `FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF`