### PR TITLE
Add `memeid-literal` with macro interpolator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ lazy val root = project
   )
 
 lazy val doobie = project
-  .in(file("doobie"))
   .dependsOn(root)
   .settings(name := "memeid-doobie")
   .settings(
@@ -29,7 +28,6 @@ lazy val doobie = project
   )
 
 lazy val circe = project
-  .in(file("circe"))
   .dependsOn(root)
   .settings(name := "memeid-circe")
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,17 @@ lazy val root = project
     )
   )
 
+lazy val literal = project
+  .dependsOn(root)
+  .settings(name := "memeid-literal")
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+      "com.chuusai"    %% "shapeless"    % "2.3.3"            % Test,
+      "org.specs2"     %% "specs2-core"  % "4.8.1"            % Test
+    )
+  )
+
 lazy val doobie = project
   .dependsOn(root)
   .settings(name := "memeid-doobie")

--- a/literal/src/main/scala/memeid/literal/Macros.scala
+++ b/literal/src/main/scala/memeid/literal/Macros.scala
@@ -1,0 +1,33 @@
+package memeid.literal
+
+import scala.reflect.macros.blackbox
+
+import memeid.UUID
+
+private[literal] class Macros(val c: blackbox.Context) {
+  import c.universe._
+
+  @SuppressWarnings(Array("scalafix:Disable.Any"))
+  def uuidInterpolator(args: Any*): c.Expr[UUID] = {
+    if (args.nonEmpty)
+      c.abort(c.enclosingPosition, "uuid interpolator should only be used on string literals")
+
+    c.prefix.tree match {
+      case interpolate(s) if isUUID(s) => c.Expr[UUID](q"_root_.memeid.UUID.from($s).right.get")
+      case interpolate(s)              => c.abort(c.enclosingPosition, s"invalid UUID: $s")
+      case _                           => c.abort(c.enclosingPosition, "should only be used on literals")
+    }
+  }
+
+  private def isUUID(s: String): Boolean = UUID.from(s).isRight
+
+  private object interpolate {
+
+    def unapply(t: c.Tree): Option[String] = t match {
+      case Apply(_, List(Apply(_, List(Literal(Constant(s: String)))))) => Some(s)
+      case _                                                            => None
+    }
+
+  }
+
+}

--- a/literal/src/main/scala/memeid/literal/package.scala
+++ b/literal/src/main/scala/memeid/literal/package.scala
@@ -1,0 +1,13 @@
+package memeid
+
+package object literal {
+
+  @SuppressWarnings(Array("scalafix:Disable.Any"))
+  implicit class UUIDInterpolator(private val sc: StringContext) extends AnyVal {
+
+    /** Validates and transforms a literal string as a valid UUID in compile time */
+    def uuid(args: Any*): UUID = macro Macros.uuidInterpolator
+
+  }
+
+}

--- a/literal/src/test/scala/memeid/literal/LiteralSpec.scala
+++ b/literal/src/test/scala/memeid/literal/LiteralSpec.scala
@@ -1,0 +1,21 @@
+package memeid.literal
+
+import memeid.UUID
+import org.specs2.mutable.Specification
+import shapeless.test.illTyped
+
+class LiteralSpec extends Specification {
+
+  "uuid interpolator" should {
+
+    "create UUID on valid string literal" >> {
+      uuid"be5cb243-06a9-409e-899f-109d0ed8ea01" must beAnInstanceOf[UUID]
+    }
+
+    "fail on invalid string literal" >> {
+      illTyped("""uuid"miau"""", "invalid UUID: miau") must beEqualTo(())
+    }
+
+  }
+
+}

--- a/src/main/scala/memeid/Constructors.scala
+++ b/src/main/scala/memeid/Constructors.scala
@@ -3,8 +3,7 @@ package memeid
 import java.util.{UUID => JUUID}
 
 import cats.effect._
-import cats.syntax.apply._
-import cats.syntax.flatMap._
+import cats.implicits._
 
 import memeid.JavaConverters._
 import memeid.bits._
@@ -25,6 +24,16 @@ trait Constructors {
    * the most/least significant bits.
    */
   def from(msb: Long, lsb: Long): UUID = new JUUID(msb, lsb).asScala
+
+  /**
+   * Creates a [[memeid.UUID UUID]] from the [[java.util.UUID#toString string standard representation]]
+   * wrapped in a [[scala.util.Right Right]].
+   *
+   * Returns [[scala.util.Left Left]] with the error in case the string doesn't follow the
+   * string standard representation.
+   */
+  def from(s: String): Either[Throwable, UUID] =
+    Either.catchNonFatal(JUUID.fromString(s).asScala)
 
   def v1[F[_]: Sync](implicit N: Node[F], T: Time[F]): F[UUID] =
     T.monotonic.flatMap { ts =>

--- a/src/test/scala/memeid/ConstructorsSpec.scala
+++ b/src/test/scala/memeid/ConstructorsSpec.scala
@@ -1,0 +1,25 @@
+package memeid
+
+import cats.implicits._
+
+import org.scalacheck.Gen
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+class ConstructorsSpec extends Specification with ScalaCheck {
+
+  "from" should {
+
+    "return Some on valid UUID" in prop { uuid: UUID =>
+      UUID.from(uuid.show) must beRight(uuid)
+    }
+
+    "return None on invalid string" in prop { s: String =>
+      UUID.from(s) must beLeft().like {
+        case e: IllegalArgumentException => e.getMessage must be equalTo s"Invalid UUID string: $s"
+      }
+    }.setGen(Gen.alphaNumStr)
+
+  }
+
+}


### PR DESCRIPTION
# What has been done in this PR?

- Create `memeid-literal` module containing macro string interpolator, which allows creating valid UUID values from a String in compile time:

```scala
uuid"be5cb243-06a9-409e-899f-109d0ed8ea01"
```

- Also provide a new `UUID.from` constructor for creating a `UUID` from a `String` returning an `Either[Throwable, UUID]`