### PR TITLE
Cats constructors

### DIFF
--- a/cats/src/main/scala/memeid/cats/implicits.scala
+++ b/cats/src/main/scala/memeid/cats/implicits.scala
@@ -1,0 +1,3 @@
+package memeid.cats
+
+object implicits extends instances with syntax

--- a/cats/src/main/scala/memeid/cats/instances.scala
+++ b/cats/src/main/scala/memeid/cats/instances.scala
@@ -2,14 +2,22 @@ package memeid.cats
 
 import java.lang.Long.compareUnsigned
 
-import cats.Show
 import cats.instances.uuid.catsStdShowForUUID
 import cats.kernel._
 import cats.syntax.contravariant._
+import cats.{Contravariant, Show}
 
 import memeid.UUID
+import memeid.digest.Digestible
 
 trait instances {
+
+  implicit def DigestibleContravariant: Contravariant[Digestible] = new Contravariant[Digestible] {
+
+    override def contramap[A, B](fa: Digestible[A])(f: B => A): Digestible[B] =
+      b => fa.toByteArray(f(b))
+
+  }
 
   implicit def UUIDHashOrderInstances: Order[UUID] with Hash[UUID] =
     new Order[UUID] with Hash[UUID] {

--- a/cats/src/main/scala/memeid/cats/syntax.scala
+++ b/cats/src/main/scala/memeid/cats/syntax.scala
@@ -1,0 +1,30 @@
+package memeid.cats
+
+import cats.effect.Sync
+
+import memeid.UUID
+import memeid.digest.Digestible
+import memeid.node.Node
+import memeid.time.Time
+
+trait syntax {
+
+  implicit class UUIDtoCatsConstructors(companion: UUID.type) {
+
+    def v1[F[_]: Sync](implicit N: Node, T: Time): F[UUID] = Sync[F].delay(UUID.V1.next(N, T))
+
+    def v3[F[_]: Sync, A: Digestible](namespace: UUID, local: A): F[UUID] =
+      Sync[F].delay(UUID.V3(namespace, local))
+
+    def v5[F[_]: Sync, A: Digestible](namespace: UUID, local: A): F[UUID] =
+      Sync[F].delay(UUID.V5(namespace, local))
+
+    def random[F[_]: Sync]: F[UUID] = Sync[F].delay(UUID.V4.random)
+
+    def squuid[F[_]: Sync](implicit T: Time): F[UUID] = Sync[F].delay(UUID.V4.squuid(T))
+
+  }
+
+}
+
+object syntax extends syntax

--- a/cats/src/test/scala/memeid/cats/SyntaxSpec.scala
+++ b/cats/src/test/scala/memeid/cats/SyntaxSpec.scala
@@ -1,0 +1,52 @@
+package memeid.cats
+
+import cats.effect.IO
+
+import memeid.UUID
+import memeid.cats.syntax._
+import org.specs2.matcher.IOMatchers
+import org.specs2.mutable.Specification
+
+class SyntaxSpec extends Specification with IOMatchers {
+
+  "v1 constructor" should {
+
+    "create version 1 UUIDs" >> {
+      UUID.v1[IO] must returnValue(anInstanceOf[UUID.V1])
+    }
+
+  }
+
+  "v3 constructor" should {
+
+    "create version 3 UUIDs" >> {
+      UUID.v3[IO, String](UUID.V4.random, "hi") must returnValue(anInstanceOf[UUID.V3])
+    }
+
+  }
+
+  "random constructor" should {
+
+    "create version 4 UUIDs" >> {
+      UUID.random[IO] must returnValue(anInstanceOf[UUID.V4])
+    }
+
+  }
+
+  "squuid constructor" should {
+
+    "create version 4 UUIDs" >> {
+      UUID.squuid[IO] must returnValue(anInstanceOf[UUID.V4])
+    }
+
+  }
+
+  "v5 constructor" should {
+
+    "create version 5 UUIDs" >> {
+      UUID.v5[IO, String](UUID.V4.random, "hi") must returnValue(anInstanceOf[UUID.V5])
+    }
+
+  }
+
+}

--- a/core/src/main/scala/memeid/UUID.scala
+++ b/core/src/main/scala/memeid/UUID.scala
@@ -10,7 +10,7 @@ import memeid.JavaConverters._
 import memeid.bits.{fromBytes, mask, readByte, toBytes, writeByte}
 import memeid.digest.{Algorithm, Digestible, MD5, SHA1}
 import memeid.node.Node
-import memeid.time.Time
+import memeid.time.{Posix, Time}
 
 /**
  * A class that represents an immutable universally unique identifier (UUID).
@@ -184,10 +184,10 @@ object UUID {
     def random: UUID = new UUID.V4(JUUID.randomUUID)
 
     // Construct a SQUUID (random, time-based) UUID.
-    def squuid(implicit T: Time): UUID = {
+    def squuid(implicit P: Posix): UUID = {
       val uuid = random
 
-      val timedMsb = (T.posix << 32) | (uuid.msb & Mask.UB32)
+      val timedMsb = (P.value << 32) | (uuid.msb & Mask.UB32)
 
       new UUID.V4(new JUUID(timedMsb, uuid.lsb))
     }

--- a/digest/src/main/scala/memeid/digest/Digestible.scala
+++ b/digest/src/main/scala/memeid/digest/Digestible.scala
@@ -4,11 +4,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 trait Digestible[A] { self =>
 
-  //TODO: Remove this and add ContravariantFunctor[Digestible] in `memeid-cats`
-  def contramap[B](f: B => A): Digestible[B] = { a: B =>
-    self.toByteArray(f(a))
-  }
-
   def toByteArray(a: A): Array[Byte]
 
 }

--- a/time/src/main/scala/memeid/time/Posix.scala
+++ b/time/src/main/scala/memeid/time/Posix.scala
@@ -1,0 +1,18 @@
+package memeid.time
+
+import java.util.concurrent.TimeUnit.MILLISECONDS
+
+/* A posix timestamp. */
+trait Posix {
+
+  def value: Long
+
+}
+
+object Posix {
+
+  implicit def apply: Posix = new Posix {
+    def value: Long = MILLISECONDS toSeconds System.currentTimeMillis
+  }
+
+}

--- a/time/src/main/scala/memeid/time/Time.scala
+++ b/time/src/main/scala/memeid/time/Time.scala
@@ -6,9 +6,6 @@ import scala.annotation.tailrec
 
 trait Time {
 
-  /* A posix timestamp. */
-  def posix: Long
-
   /* A gregorian time monotonic timestamp. */
   def monotonic: Long
 
@@ -57,9 +54,7 @@ object Time {
 
   implicit def apply: Time = new Time {
 
-    def posix: Long = current / 1000
-
-    def monotonic: Long =
+    override def monotonic: Long =
       state.updateAndGet(_.update(current)).timestamp
 
   }


### PR DESCRIPTION
# What has been done in this PR?

- Create constructors that wrap the different version constructors in an effect.
- Extract `posix` from `Time` so we can derive it from cats `Clock`
- Add `Contravariant` instance for `Digestible` 

# Referenced issue

This closes #41 