### PR TITLE
Add unapply to extract UUID from String

### DIFF
--- a/core/src/main/scala/memeid/UUID.scala
+++ b/core/src/main/scala/memeid/UUID.scala
@@ -92,8 +92,9 @@ sealed trait UUID extends Comparable[UUID] {
 
 object UUID {
 
-  implicit val DigestibleUUIDInstance: Digestible[UUID] =
-    u => toBytes(u.msb) ++ toBytes(u.lsb)
+  def unapply(str: String): Option[UUID] =
+    if (!str.isEmpty) UUID.from(str).toOption
+    else None
 
   /**
    * Creates a valid [[UUID]] from two [[Long]] values representing
@@ -244,5 +245,8 @@ object UUID {
     def version(msb: Long, version: Long): Long =
       writeByte(VERSION, msb, version)
   }
+
+  implicit val DigestibleUUIDInstance: Digestible[UUID] =
+    u => toBytes(u.msb) ++ toBytes(u.lsb)
 
 }

--- a/core/src/test/scala/memeid/UUIDSpec.scala
+++ b/core/src/test/scala/memeid/UUIDSpec.scala
@@ -161,4 +161,16 @@ class UUIDSpec extends Specification with ScalaCheck {
 
   }
 
+  "unapply" should {
+
+    "extract valid uuid string as UUID" in prop { uuid: UUID =>
+      UUID.unapply(uuid.toString) must be some uuid
+    }
+
+    "fail on invalid uuid string as UUID" in prop { string: String =>
+      UUID.unapply(string) must beNone
+    }.setGen(Gen.alphaNumStr)
+
+  }
+
 }


### PR DESCRIPTION
# What has been done in this PR?

Create `unapply` method so we can automatically extract `UUID` from `String` values:

```scala
"13ea2ea9-6e30-4160-8491-f8d900eadb8f" match {
	case UUID(uuid) => ???
	case _          => ???
}
```

or...

```scala
case GET -> Root / "users" / UUID(userID) => ???
```