### PR TITLE
Add support for http4s

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,3 +52,8 @@ lazy val circe = project
   .dependsOn(cats)
   .settings(name := "memeid-circe")
   .settings(dependencies.common, dependencies.circe)
+
+lazy val http4s = project
+  .dependsOn(cats)
+  .settings(name := "memeid-http4s")
+  .settings(dependencies.common, dependencies.http4s)

--- a/http4s/src/main/scala/memeid/http4s/implicits.scala
+++ b/http4s/src/main/scala/memeid/http4s/implicits.scala
@@ -1,0 +1,3 @@
+package memeid.http4s
+
+object implicits extends instances

--- a/http4s/src/main/scala/memeid/http4s/instances.scala
+++ b/http4s/src/main/scala/memeid/http4s/instances.scala
@@ -1,0 +1,25 @@
+package memeid.http4s
+
+import memeid.cats.instances._
+import cats.syntax.show._
+import cats.syntax.either._
+import memeid.UUID
+import org.http4s.{ParseFailure, QueryParamDecoder, QueryParamEncoder}
+
+trait instances {
+
+  /** Allow reading UUIDs from a request's query params */
+  implicit val UUIDQueryParamDecoderInstance: QueryParamDecoder[UUID] =
+    QueryParamDecoder[String].emap { s =>
+      UUID.from(s).leftMap { e =>
+        ParseFailure(s"Failed to decode value: $s as UUID", e.getMessage)
+      }
+    }
+
+  /** Allow using UUIDs in a request's query params */
+  implicit val UUIDQueryParamEncoderInstance: QueryParamEncoder[UUID] =
+    QueryParamEncoder[String].contramap(_.show)
+
+}
+
+object instances extends instances

--- a/http4s/src/test/scala/memeid/http4s/InstancesSpec.scala
+++ b/http4s/src/test/scala/memeid/http4s/InstancesSpec.scala
@@ -1,0 +1,44 @@
+package memeid.http4s
+
+import memeid.UUID
+import memeid.http4s.instances._
+import cats.syntax.show._
+import memeid.cats.instances._
+import org.http4s.{QueryParamEncoder, QueryParameterValue}
+import org.http4s.dsl.impl.QueryParamDecoderMatcher
+import org.scalacheck.Gen
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+class InstancesSpec extends Specification with ScalaCheck {
+
+  object QueryParamMatcher extends QueryParamDecoderMatcher[UUID]("miau")
+
+  "QueryParamDecoder[UUID]" should {
+
+    "correctly decode a valid UUID" in prop { uuid: UUID =>
+      val queryParams = Map("miau" -> List(uuid.show))
+
+      QueryParamMatcher.unapply(queryParams) must be some uuid
+    }
+
+    "fail given an invalid UUID" in prop { string: String =>
+      val queryParams = Map("miau" -> List(string))
+
+      QueryParamMatcher.unapply(queryParams) must beNone
+    }.setGen(Gen.alphaNumStr)
+
+  }
+
+  "QueryParamEncoder[UUID]" should {
+
+    "correctly encode a valid UUID" in prop { uuid: UUID =>
+      val QueryParameterValue(string) = QueryParamEncoder[UUID].encode(uuid)
+
+      string should be equalTo uuid.show
+
+    }
+
+  }
+
+}

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,6 +9,7 @@ object dependencies {
     val circe               = "0.12.3"
     val `discipline-specs2` = "1.0.0"
     val doobie              = "0.8.8"
+    val http4s              = "0.21.0-M6"
     val specs               = "4.8.1"
     val shapeless           = "2.3.3"
 
@@ -39,6 +40,11 @@ object dependencies {
 
   val circe: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "io.circe" %% "circe-core" % V.circe
+  )
+
+  val http4s: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
+    "org.http4s" %% "http4s-core" % V.http4s,
+    "org.http4s" %% "http4s-dsl"  % V.http4s % Test
   )
 
 }


### PR DESCRIPTION
# What has been done in this PR?

- Create `memeid-http4s` project for http4s integration
- Add instances for `QueryParamDecoder`/`QueryParamEncoder` for `UUID`

# Referenced issue

This closes #11
