### PR TITLE
May the F be with you

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val cats = project
   .dependsOn(core % "compile->compile;test->test")
   .settings(name := "memeid-cats")
   .settings(dependencies.common, dependencies.cats)
+  .settings(dependencies.compilerPlugins)
 
 lazy val literal = project
   .dependsOn(core)

--- a/cats/src/main/scala/memeid/cats/syntax.scala
+++ b/cats/src/main/scala/memeid/cats/syntax.scala
@@ -30,26 +30,23 @@ trait syntax {
 
   implicit class UUIDtoCatsConstructors(companion: UUID.type) {
 
-    def v1[F[_]: Sync](implicit N: Node, T: Time): F[UUID] = Sync[F].delay(UUID.V1.next(N, T))
+    def v1[F[_]: Sync](implicit N: Node, T: Time): F[UUID] = F.delay(UUID.V1.next(N, T))
 
     def v3[F[_]: Sync, A: Digestible](namespace: UUID, local: A): F[UUID] =
-      Sync[F].delay(UUID.V3(namespace, local))
+      F.delay(UUID.V3(namespace, local))
 
     def v5[F[_]: Sync, A: Digestible](namespace: UUID, local: A): F[UUID] =
-      Sync[F].delay(UUID.V5(namespace, local))
+      F.delay(UUID.V5(namespace, local))
 
-    def random[F[_]: Sync]: F[UUID] = Sync[F].delay(UUID.V4.random)
+    def random[F[_]: Sync]: F[UUID] = F.delay(UUID.V4.random)
 
-    def squuid[F[_]: Sync: Clock]: F[UUID] =
-      Clock[F]
-        .realTime(SECONDS)
-        .map { s =>
-          UUID.V4.squuid {
-            new Posix {
-              override def value: Long = s
-            }
-          }
+    def squuid[F[_]: Sync: Clock]: F[UUID] = F.realTime(SECONDS).map { s =>
+      UUID.V4.squuid {
+        new Posix {
+          override def value: Long = s
         }
+      }
+    }
 
   }
 

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.{Def, _}
 import sbt.Keys._
 
 object dependencies {
@@ -45,6 +45,10 @@ object dependencies {
   val http4s: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "org.http4s" %% "http4s-core" % V.http4s,
     "org.http4s" %% "http4s-dsl"  % V.http4s % Test
+  )
+
+  val compilerPlugins: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
+    compilerPlugin("org.augustjune" %% "context-applied" % "0.1.2")
   )
 
 }


### PR DESCRIPTION
# What has been done in this PR?

Add [`context-applied`](https://github.com/augustjune/context-applied) as a compiler plugin for `memeid-cats` so we can

```scala
def fn[F[_]: Monad]: F[Int] = F.pure(12)
```

instead of:

```scala
def fn[F[_]: Monad]: F[Int] = Monad[F].pure(12)
```