### PR TITLE
Make `memeid-literal` depend only on Java module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val `memeid-cats` = project
   .settings(dependencies.compilerPlugins)
 
 lazy val `memeid-literal` = project
-  .dependsOn(`memeid-scala`)
+  .dependsOn(memeid)
   .settings(dependencies.common, dependencies.literal)
 
 lazy val `memeid-doobie` = project

--- a/memeid-literal/src/main/scala/memeid/literal/Macros.scala
+++ b/memeid-literal/src/main/scala/memeid/literal/Macros.scala
@@ -18,7 +18,7 @@ package memeid.literal
 
 import scala.reflect.macros.blackbox
 
-import memeid.scala.UUID
+import memeid.UUID
 
 private[literal] class Macros(val c: blackbox.Context) {
   import c.universe._
@@ -30,13 +30,13 @@ private[literal] class Macros(val c: blackbox.Context) {
 
     c.prefix.tree match {
       case interpolate(s) if isUUID(s) =>
-        c.Expr[UUID](q"_root_.memeid.scala.UUID.from($s).right.get")
+        c.Expr[UUID](q"_root_.memeid.UUID.fromString($s)")
       case interpolate(s) => c.abort(c.enclosingPosition, s"invalid UUID: $s")
       case _              => c.abort(c.enclosingPosition, "should only be used on literals")
     }
   }
 
-  private def isUUID(s: String): Boolean = UUID.from(s).isRight
+  private def isUUID(s: String): Boolean = _root_.scala.util.Try(UUID.fromString(s)).isSuccess
 
   private object interpolate {
 

--- a/memeid-literal/src/test/scala/memeid/literal/LiteralSpec.scala
+++ b/memeid-literal/src/test/scala/memeid/literal/LiteralSpec.scala
@@ -16,7 +16,7 @@
 
 package memeid.literal
 
-import memeid.scala.UUID
+import memeid.UUID
 import org.specs2.mutable.Specification
 import shapeless.test.illTyped
 


### PR DESCRIPTION
# What has been done in this PR?

`memeid-literal` doesn't need to depend on `memeid-scala` it is enough to depend on plain Java `memeid`.